### PR TITLE
Stephanie

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,7 @@ class App extends React.Component {
     let { covidCheck, searchTerm, articles, filterTerm } = this.state
     let anArray = [...articles]
 
-    if (covidCheck === true) {
+    if (covidCheck) {
       anArray = articles.filter((article) => {
         return article.description === null
         ?
@@ -108,7 +108,7 @@ class App extends React.Component {
         !article.title.toLowerCase().includes("coronavirus") && !article.description.toLowerCase().includes("coronavirus")
       })
 
-    } else if (covidCheck === false) {
+    } else if (!covidCheck) {
       anArray = articles.filter((article) => {
         return article.description === null
           ?
@@ -117,33 +117,33 @@ class App extends React.Component {
           article.description.toLowerCase().includes(searchTerm.toLowerCase())
           || article.title.toLowerCase().includes(searchTerm.toLowerCase())
       })
-
-    } else if (filterTerm !== "") {
-      anArray = articles.map((article) => {
-        return article.joiners.filter((joiner) => {
-          joiner.filter((joiner) => {
-            return joiner.tag_name === filterTerm
-          })
-        })
-      })
+    // } else if (filterTerm !== "") {
+    //   anArray = articles.filter((article) => {
+    //     return article.joiners.map((joiner) => {
+    //       joiner.filter((joiner) => {
+    //         return joiner.tag_name === filterTerm
+    //       })
+    //     })
+    //   })
     }
     return anArray
   }
 
-  // pickArticles = () => {
-  //   let { searchTerm, articles } = this.state
-  //   let newArray = [...articles]
-  //   if (searchTerm === "") {
-  //     return newArray
-  //   } else {
-  //     newArray = articles.filter((article) => {
-  //       article.joiners.map((joiner) => {
-  //         return joiner.tag_name === searchTerm.replace(/[^A-Za-z0-9_]/g,"")
-  //       })
-  //     })
-  //   }
-  //   return newArray
-  // }
+
+  pickArticles = () => {
+    let { searchTerm, articles } = this.state
+    let newArray = [...articles]
+    if (searchTerm === "") {
+      return newArray
+    } else {
+      newArray = articles.filter((article) => {
+        article.joiners.map((joiner) => {
+          return joiner.tag_name === searchTerm.replace(/[^A-Za-z0-9_]/g,"")
+        })
+      })
+    }
+    return newArray
+  }
 
   componentDidMount() {
     fetch("http://localhost:3000/articles")

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import ArticlesContainer from './ArticlesContainer.jsx'
 import SearchArticles from './SearchArticles.jsx'
 import TagsContainer from './TagsContainer.jsx'
 import CovidToggle from './CovidToggle.jsx'
-import Article from './Article'
 
 class App extends React.Component {
 
@@ -13,7 +12,13 @@ class App extends React.Component {
     searchTerm: "",
     covidCheck: false,
     allTags: [],
-    arrayOfThingsToCheckFor: [],
+    filterTerm: ""
+  }
+
+  handleFilterTerm = (filterFromChild) => {
+    this.setState({
+      filterTerm: filterFromChild
+    })
   }
 
   formatDateTime(date) {
@@ -91,7 +96,7 @@ class App extends React.Component {
   }
 
   decideWhichArrayToRender = () => {
-    let { covidCheck, searchTerm, articles } = this.state
+    let { covidCheck, searchTerm, articles, filterTerm } = this.state
     let anArray = [...articles]
 
     if (covidCheck === true) {
@@ -102,6 +107,7 @@ class App extends React.Component {
         :
         !article.title.toLowerCase().includes("coronavirus") && !article.description.toLowerCase().includes("coronavirus")
       })
+
     } else if (covidCheck === false) {
       anArray = articles.filter((article) => {
         return article.description === null
@@ -111,25 +117,33 @@ class App extends React.Component {
           article.description.toLowerCase().includes(searchTerm.toLowerCase())
           || article.title.toLowerCase().includes(searchTerm.toLowerCase())
       })
+
+    } else if (filterTerm !== "") {
+      anArray = articles.map((article) => {
+        return article.joiners.filter((joiner) => {
+          joiner.filter((joiner) => {
+            return joiner.tag_name === filterTerm
+          })
+        })
+      })
     }
     return anArray
   }
 
-  pickArticles = () => {
-    let { searchTerm, articles } = this.state
-    let newArray = [...articles]
-
-    if (searchTerm === "") {
-      return newArray
-    } else {
-      newArray = articles.filter((article) => {
-        article.joiners.map((joiner) => {
-          return joiner.tag_name === searchTerm.replace(/[^A-Za-z0-9_]/g,"")
-        })
-      })
-    }
-    return newArray
-  }
+  // pickArticles = () => {
+  //   let { searchTerm, articles } = this.state
+  //   let newArray = [...articles]
+  //   if (searchTerm === "") {
+  //     return newArray
+  //   } else {
+  //     newArray = articles.filter((article) => {
+  //       article.joiners.map((joiner) => {
+  //         return joiner.tag_name === searchTerm.replace(/[^A-Za-z0-9_]/g,"")
+  //       })
+  //     })
+  //   }
+  //   return newArray
+  // }
 
   componentDidMount() {
     fetch("http://localhost:3000/articles")
@@ -150,13 +164,18 @@ class App extends React.Component {
 
   render(){
 
+    console.log("filter term:", this.state.filterTerm)
+    console.log("article:", this.state.articles)
+
+
     return (
   
       <div className="App">
-        <h1 className="header">The Hegel Bagel 📖</h1>
+        <h1 className="header">Hegelian Bagel 🥯</h1>
         <TagsContainer 
           tags={this.state.allTags}
           handleSearchTerm={this.handleSearchTerm}
+          handleFilterTerm={this.handleFilterTerm}
         />
         <CovidToggle
           covidCheck = {this.state.covidCheck}

--- a/src/Tag.jsx
+++ b/src/Tag.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 class Tag extends Component {
 
   handleTagFilter = (event) => {
-    this.props.handleFilterTerm(event.target.innerText)
+    this.props.handleSearchTerm(event.target.innerText)
     console.log(event.target.innerText)
   }
 

--- a/src/Tag.jsx
+++ b/src/Tag.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 class Tag extends Component {
 
   handleTagFilter = (event) => {
-    this.props.handleSearchTerm(event.target.innerText)
+    this.props.handleFilterTerm(event.target.innerText)
     console.log(event.target.innerText)
   }
 
@@ -12,7 +12,7 @@ class Tag extends Component {
   return (
     <>
       <button className="tag" onClick={this.handleTagFilter}>
-        #{ content } 
+        { content } 
       </button>
     </>
   )

--- a/src/TagsContainer.jsx
+++ b/src/TagsContainer.jsx
@@ -10,6 +10,7 @@ class TagsContainer extends Component {
         key={tag.id}
         tag={tag}
         handleSearchTerm={this.props.handleSearchTerm}
+        handleFilterTerm={this.props.handleFilterTerm}
       />
     })
 


### PR DESCRIPTION
* debugged one issue which is that we can filter out the filters using the method you built if we just remove the # in the Tag component as it wasn't matching up with the articles
* built a new way to control the tag filter component --> filterTerm instead of searchTerm but commented it out
* if we push the filtering into the search term instead of filter term, we are pushing it into our search logic of filtering by description instead of tags, can't access tags for now because POJO depth issue (joiners --> joiner --> tag_name)
* bug: by refactoring the decideWhichArrayToRender such that the search logic is conditional on the corona toggle, the search bar can't be used when the corona toggle is turned on.
* currently the filter only filters for title names and descriptions